### PR TITLE
calc_directionの修正

### DIFF
--- a/ptcs/docs/ポイントの向き.drawio
+++ b/ptcs/docs/ポイントの向き.drawio
@@ -1,40 +1,40 @@
-<mxfile host="Electron" modified="2023-05-06T12:53:23.833Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/21.2.8 Chrome/112.0.5615.165 Electron/24.2.0 Safari/537.36" etag="jSZYRAxsc2oGH3FY4EpP" version="21.2.8" type="device" pages="3">
-  <diagram name="通常時" id="arh3FIw3pBXTjxhgvzi6">
-    <mxGraphModel dx="358" dy="240" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+<mxfile host="Electron" modified="2023-05-09T12:27:34.628Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/21.2.8 Chrome/112.0.5615.165 Electron/24.2.0 Safari/537.36" etag="FFpPNpK2nUJ9_qfxjfEp" version="21.2.8" type="device" pages="4">
+  <diagram name="pattern1" id="arh3FIw3pBXTjxhgvzi6">
+    <mxGraphModel dx="984" dy="718" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
-        <mxCell id="7u-3wQYrSJS738qDRrCc-1" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-1" value="" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
           <mxGeometry x="430" y="140" width="60" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-2" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-2" value="" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
           <mxGeometry x="430" width="60" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-3" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="1">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-3" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="400" y="100" as="sourcePoint" />
             <mxPoint x="520" y="100" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-4" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="1">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-4" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="440" y="60" as="sourcePoint" />
             <mxPoint x="480" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-5" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="1" source="7u-3wQYrSJS738qDRrCc-24">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-5" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="1" source="7u-3wQYrSJS738qDRrCc-24" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="400" y="100" as="sourcePoint" />
             <mxPoint x="440" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-6" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="1" source="7u-3wQYrSJS738qDRrCc-26">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-6" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="1" source="7u-3wQYrSJS738qDRrCc-26" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="520" y="100" as="sourcePoint" />
             <mxPoint x="480" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-7" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="1">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-7" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="480" y="60" as="sourcePoint" />
             <mxPoint x="520" y="100" as="targetPoint" />
@@ -48,94 +48,94 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-8" value="j0a" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="1">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-8" value="j0a" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="1" vertex="1">
           <mxGeometry x="390" y="110" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-9" value="j0b" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="1">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-9" value="j0b" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="1" vertex="1">
           <mxGeometry x="420" y="20" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-10" value="j1a" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="1">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-10" value="j1a" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="1" vertex="1">
           <mxGeometry x="500" y="110" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-11" value="j1b" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="1">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-11" value="j1b" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="1" vertex="1">
           <mxGeometry x="460" y="20" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-12" value="s1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="1">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-12" value="s1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="1" vertex="1">
           <mxGeometry x="440" y="60" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-13" value="s2" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="1">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-13" value="s2" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="1" vertex="1">
           <mxGeometry x="600" y="70" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-14" value="s3" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="1">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-14" value="s3" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="1" vertex="1">
           <mxGeometry x="440" y="120" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-15" value="s4" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="1">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-15" value="s4" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="1" vertex="1">
           <mxGeometry x="380" y="70" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-16" value="s5" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="1">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-16" value="s5" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="1" vertex="1">
           <mxGeometry x="500" y="70" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-18" value="" style="endArrow=none;html=1;rounded=0;" edge="1" parent="1" source="7u-3wQYrSJS738qDRrCc-21">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-18" value="" style="endArrow=none;html=1;rounded=0;" parent="1" source="7u-3wQYrSJS738qDRrCc-21" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="370" y="60" as="sourcePoint" />
             <mxPoint x="440" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-19" value="" style="endArrow=none;html=1;rounded=0;" edge="1" parent="1">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-19" value="" style="endArrow=none;html=1;rounded=0;" parent="1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="370" y="100" as="sourcePoint" />
             <mxPoint x="400" y="100" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-22" value="" style="endArrow=none;html=1;rounded=0;" edge="1" parent="1" target="7u-3wQYrSJS738qDRrCc-21">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-22" value="" style="endArrow=none;html=1;rounded=0;" parent="1" target="7u-3wQYrSJS738qDRrCc-21" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="370" y="60" as="sourcePoint" />
             <mxPoint x="440" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-21" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="1">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-21" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="1" vertex="1">
           <mxGeometry x="430" y="50" width="20" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-23" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="1">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-23" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="1" vertex="1">
           <mxGeometry x="470" y="50" width="20" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-25" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="1" target="7u-3wQYrSJS738qDRrCc-24">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-25" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="1" target="7u-3wQYrSJS738qDRrCc-24" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="400" y="100" as="sourcePoint" />
             <mxPoint x="440" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-24" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="1">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-24" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="1" vertex="1">
           <mxGeometry x="390" y="90" width="20" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-27" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="1" target="7u-3wQYrSJS738qDRrCc-26">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-27" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="1" target="7u-3wQYrSJS738qDRrCc-26" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="520" y="100" as="sourcePoint" />
             <mxPoint x="480" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-26" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="1">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-26" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="1" vertex="1">
           <mxGeometry x="510" y="90" width="20" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-28" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="7u-3wQYrSJS738qDRrCc-21" target="7u-3wQYrSJS738qDRrCc-21">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-28" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="7u-3wQYrSJS738qDRrCc-21" target="7u-3wQYrSJS738qDRrCc-21" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="320" y="70" as="sourcePoint" />
             <mxPoint x="350" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-29" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-29" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" parent="1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="470" y="60" as="sourcePoint" />
             <mxPoint x="490" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-30" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="7u-3wQYrSJS738qDRrCc-24" target="7u-3wQYrSJS738qDRrCc-24">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-30" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="7u-3wQYrSJS738qDRrCc-24" target="7u-3wQYrSJS738qDRrCc-24" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="450" y="80" as="sourcePoint" />
             <mxPoint x="470" y="80" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="7u-3wQYrSJS738qDRrCc-31" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1">
+        <mxCell id="7u-3wQYrSJS738qDRrCc-31" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" parent="1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="510" y="99.82" as="sourcePoint" />
             <mxPoint x="530" y="99.82" as="targetPoint" />
@@ -144,42 +144,187 @@
       </root>
     </mxGraphModel>
   </diagram>
-  <diagram name="S3通行不可1" id="a9ny2blX0CzjCBRiFFUc">
-    <mxGraphModel dx="419" dy="281" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+  <diagram name="pattern2" id="spZ5XvLSFX5mMCUu9n3Z">
+    <mxGraphModel dx="984" dy="718" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+      <root>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-0" />
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-1" parent="KMXKlcnqYH1HJKnBzze7-0" />
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-2" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+          <mxGeometry x="430" y="140" width="60" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-3" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+          <mxGeometry x="430" width="60" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-4" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="400" y="100" as="sourcePoint" />
+            <mxPoint x="520" y="100" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-5" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="440" y="60" as="sourcePoint" />
+            <mxPoint x="480" y="60" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-6" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1" source="KMXKlcnqYH1HJKnBzze7-24">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="400" y="100" as="sourcePoint" />
+            <mxPoint x="440" y="60" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-7" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1" source="KMXKlcnqYH1HJKnBzze7-26">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="520" y="100" as="sourcePoint" />
+            <mxPoint x="480" y="60" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-8" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="480" y="60" as="sourcePoint" />
+            <mxPoint x="520" y="100" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="560" y="60" />
+              <mxPoint x="580" y="40" />
+              <mxPoint x="640" y="40" />
+              <mxPoint x="640" y="120" />
+              <mxPoint x="580" y="120" />
+              <mxPoint x="560" y="100" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-9" value="j0a" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+          <mxGeometry x="390" y="110" width="40" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-10" value="j0b" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+          <mxGeometry x="420" y="20" width="40" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-11" value="j1a" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+          <mxGeometry x="500" y="110" width="40" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-12" value="j1b" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+          <mxGeometry x="460" y="20" width="40" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-13" value="s1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+          <mxGeometry x="440" y="60" width="40" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-14" value="s2" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+          <mxGeometry x="600" y="70" width="40" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-15" value="s3" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+          <mxGeometry x="440" y="120" width="40" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-16" value="s4" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+          <mxGeometry x="380" y="70" width="40" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-17" value="s5" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+          <mxGeometry x="500" y="70" width="40" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-18" value="" style="endArrow=none;html=1;rounded=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1" source="KMXKlcnqYH1HJKnBzze7-21">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="370" y="60" as="sourcePoint" />
+            <mxPoint x="440" y="60" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-19" value="" style="endArrow=none;html=1;rounded=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="370" y="100" as="sourcePoint" />
+            <mxPoint x="400" y="100" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-20" value="" style="endArrow=none;html=1;rounded=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1" target="KMXKlcnqYH1HJKnBzze7-21">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="370" y="60" as="sourcePoint" />
+            <mxPoint x="440" y="60" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-21" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+          <mxGeometry x="430" y="50" width="20" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-22" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+          <mxGeometry x="470" y="50" width="20" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-23" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1" target="KMXKlcnqYH1HJKnBzze7-24">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="400" y="100" as="sourcePoint" />
+            <mxPoint x="440" y="60" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-24" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+          <mxGeometry x="390" y="90" width="20" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-25" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1" target="KMXKlcnqYH1HJKnBzze7-26">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="520" y="100" as="sourcePoint" />
+            <mxPoint x="480" y="60" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-26" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+          <mxGeometry x="510" y="90" width="20" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-27" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1" source="KMXKlcnqYH1HJKnBzze7-21" target="KMXKlcnqYH1HJKnBzze7-21">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="320" y="70" as="sourcePoint" />
+            <mxPoint x="350" y="60" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-28" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="470" y="60" as="sourcePoint" />
+            <mxPoint x="490" y="60" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-29" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=1;exitY=0;exitDx=0;exitDy=0;entryX=0;entryY=1;entryDx=0;entryDy=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1" source="KMXKlcnqYH1HJKnBzze7-24" target="KMXKlcnqYH1HJKnBzze7-24">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="450" y="80" as="sourcePoint" />
+            <mxPoint x="470" y="80" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-30" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="510" y="99.82" as="sourcePoint" />
+            <mxPoint x="530" y="99.82" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+  <diagram name="pattern3" id="a9ny2blX0CzjCBRiFFUc">
+    <mxGraphModel dx="984" dy="718" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
       <root>
         <mxCell id="-IiezHLQpp2U1VbSaJ5H-0" />
         <mxCell id="-IiezHLQpp2U1VbSaJ5H-1" parent="-IiezHLQpp2U1VbSaJ5H-0" />
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-2" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="-IiezHLQpp2U1VbSaJ5H-1">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-2" value="" style="rounded=0;whiteSpace=wrap;html=1;" parent="-IiezHLQpp2U1VbSaJ5H-1" vertex="1">
           <mxGeometry x="430" y="140" width="60" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-3" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="-IiezHLQpp2U1VbSaJ5H-1">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-3" value="" style="rounded=0;whiteSpace=wrap;html=1;" parent="-IiezHLQpp2U1VbSaJ5H-1" vertex="1">
           <mxGeometry x="430" width="60" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-4" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;fillColor=#e51400;strokeColor=#B20000;" edge="1" parent="-IiezHLQpp2U1VbSaJ5H-1">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-4" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;fillColor=#e51400;strokeColor=#B20000;" parent="-IiezHLQpp2U1VbSaJ5H-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="400" y="100" as="sourcePoint" />
             <mxPoint x="520" y="100" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-5" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="-IiezHLQpp2U1VbSaJ5H-1">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-5" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="-IiezHLQpp2U1VbSaJ5H-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="440" y="60" as="sourcePoint" />
             <mxPoint x="480" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-6" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="-IiezHLQpp2U1VbSaJ5H-1" source="-IiezHLQpp2U1VbSaJ5H-24">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-6" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="-IiezHLQpp2U1VbSaJ5H-1" source="-IiezHLQpp2U1VbSaJ5H-24" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="400" y="100" as="sourcePoint" />
             <mxPoint x="440" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-7" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="-IiezHLQpp2U1VbSaJ5H-1" source="-IiezHLQpp2U1VbSaJ5H-26">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-7" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="-IiezHLQpp2U1VbSaJ5H-1" source="-IiezHLQpp2U1VbSaJ5H-26" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="520" y="100" as="sourcePoint" />
             <mxPoint x="480" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-8" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="-IiezHLQpp2U1VbSaJ5H-1">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-8" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="-IiezHLQpp2U1VbSaJ5H-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="480" y="60" as="sourcePoint" />
             <mxPoint x="520" y="100" as="targetPoint" />
@@ -193,94 +338,94 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-9" value="j0a" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="-IiezHLQpp2U1VbSaJ5H-1">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-9" value="j0a" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="-IiezHLQpp2U1VbSaJ5H-1" vertex="1">
           <mxGeometry x="390" y="110" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-10" value="j0b" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="-IiezHLQpp2U1VbSaJ5H-1">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-10" value="j0b" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="-IiezHLQpp2U1VbSaJ5H-1" vertex="1">
           <mxGeometry x="420" y="20" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-11" value="j1a" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="-IiezHLQpp2U1VbSaJ5H-1">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-11" value="j1a" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="-IiezHLQpp2U1VbSaJ5H-1" vertex="1">
           <mxGeometry x="500" y="110" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-12" value="j1b" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="-IiezHLQpp2U1VbSaJ5H-1">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-12" value="j1b" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="-IiezHLQpp2U1VbSaJ5H-1" vertex="1">
           <mxGeometry x="460" y="20" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-13" value="s1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="-IiezHLQpp2U1VbSaJ5H-1">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-13" value="s1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="-IiezHLQpp2U1VbSaJ5H-1" vertex="1">
           <mxGeometry x="440" y="60" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-14" value="s2" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="-IiezHLQpp2U1VbSaJ5H-1">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-14" value="s2" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="-IiezHLQpp2U1VbSaJ5H-1" vertex="1">
           <mxGeometry x="600" y="70" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-15" value="s3" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="-IiezHLQpp2U1VbSaJ5H-1">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-15" value="s3" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="-IiezHLQpp2U1VbSaJ5H-1" vertex="1">
           <mxGeometry x="440" y="120" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-16" value="s4" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="-IiezHLQpp2U1VbSaJ5H-1">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-16" value="s4" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="-IiezHLQpp2U1VbSaJ5H-1" vertex="1">
           <mxGeometry x="380" y="70" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-17" value="s5" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="-IiezHLQpp2U1VbSaJ5H-1">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-17" value="s5" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="-IiezHLQpp2U1VbSaJ5H-1" vertex="1">
           <mxGeometry x="500" y="70" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-18" value="" style="endArrow=none;html=1;rounded=0;" edge="1" parent="-IiezHLQpp2U1VbSaJ5H-1" source="-IiezHLQpp2U1VbSaJ5H-21">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-18" value="" style="endArrow=none;html=1;rounded=0;" parent="-IiezHLQpp2U1VbSaJ5H-1" source="-IiezHLQpp2U1VbSaJ5H-21" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="370" y="60" as="sourcePoint" />
             <mxPoint x="440" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-19" value="" style="endArrow=none;html=1;rounded=0;" edge="1" parent="-IiezHLQpp2U1VbSaJ5H-1">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-19" value="" style="endArrow=none;html=1;rounded=0;" parent="-IiezHLQpp2U1VbSaJ5H-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="370" y="100" as="sourcePoint" />
             <mxPoint x="400" y="100" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-20" value="" style="endArrow=none;html=1;rounded=0;" edge="1" parent="-IiezHLQpp2U1VbSaJ5H-1" target="-IiezHLQpp2U1VbSaJ5H-21">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-20" value="" style="endArrow=none;html=1;rounded=0;" parent="-IiezHLQpp2U1VbSaJ5H-1" target="-IiezHLQpp2U1VbSaJ5H-21" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="370" y="60" as="sourcePoint" />
             <mxPoint x="440" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-21" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="-IiezHLQpp2U1VbSaJ5H-1">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-21" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="-IiezHLQpp2U1VbSaJ5H-1" vertex="1">
           <mxGeometry x="430" y="50" width="20" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-22" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="-IiezHLQpp2U1VbSaJ5H-1">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-22" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="-IiezHLQpp2U1VbSaJ5H-1" vertex="1">
           <mxGeometry x="470" y="50" width="20" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-23" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="-IiezHLQpp2U1VbSaJ5H-1" target="-IiezHLQpp2U1VbSaJ5H-24">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-23" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="-IiezHLQpp2U1VbSaJ5H-1" target="-IiezHLQpp2U1VbSaJ5H-24" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="400" y="100" as="sourcePoint" />
             <mxPoint x="440" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-24" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="-IiezHLQpp2U1VbSaJ5H-1">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-24" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="-IiezHLQpp2U1VbSaJ5H-1" vertex="1">
           <mxGeometry x="390" y="90" width="20" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-25" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="-IiezHLQpp2U1VbSaJ5H-1" target="-IiezHLQpp2U1VbSaJ5H-26">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-25" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="-IiezHLQpp2U1VbSaJ5H-1" target="-IiezHLQpp2U1VbSaJ5H-26" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="520" y="100" as="sourcePoint" />
             <mxPoint x="480" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-26" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="-IiezHLQpp2U1VbSaJ5H-1">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-26" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="-IiezHLQpp2U1VbSaJ5H-1" vertex="1">
           <mxGeometry x="510" y="90" width="20" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-27" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="-IiezHLQpp2U1VbSaJ5H-1" source="-IiezHLQpp2U1VbSaJ5H-21" target="-IiezHLQpp2U1VbSaJ5H-21">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-27" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" parent="-IiezHLQpp2U1VbSaJ5H-1" source="-IiezHLQpp2U1VbSaJ5H-21" target="-IiezHLQpp2U1VbSaJ5H-21" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="320" y="70" as="sourcePoint" />
             <mxPoint x="350" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-28" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="-IiezHLQpp2U1VbSaJ5H-1">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-28" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" parent="-IiezHLQpp2U1VbSaJ5H-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="470" y="60" as="sourcePoint" />
             <mxPoint x="490" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-29" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=1;exitY=0;exitDx=0;exitDy=0;entryX=0;entryY=1;entryDx=0;entryDy=0;" edge="1" parent="-IiezHLQpp2U1VbSaJ5H-1" source="-IiezHLQpp2U1VbSaJ5H-24" target="-IiezHLQpp2U1VbSaJ5H-24">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-29" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=1;exitY=0;exitDx=0;exitDy=0;entryX=0;entryY=1;entryDx=0;entryDy=0;" parent="-IiezHLQpp2U1VbSaJ5H-1" source="-IiezHLQpp2U1VbSaJ5H-24" target="-IiezHLQpp2U1VbSaJ5H-24" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="450" y="80" as="sourcePoint" />
             <mxPoint x="470" y="80" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="-IiezHLQpp2U1VbSaJ5H-30" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=0;exitDx=0;exitDy=0;entryX=1;entryY=1;entryDx=0;entryDy=0;" edge="1" parent="-IiezHLQpp2U1VbSaJ5H-1" source="-IiezHLQpp2U1VbSaJ5H-26" target="-IiezHLQpp2U1VbSaJ5H-26">
+        <mxCell id="-IiezHLQpp2U1VbSaJ5H-30" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=0;exitDx=0;exitDy=0;entryX=1;entryY=1;entryDx=0;entryDy=0;" parent="-IiezHLQpp2U1VbSaJ5H-1" source="-IiezHLQpp2U1VbSaJ5H-26" target="-IiezHLQpp2U1VbSaJ5H-26" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="510" y="99.82" as="sourcePoint" />
             <mxPoint x="530" y="99.82" as="targetPoint" />
@@ -289,42 +434,42 @@
       </root>
     </mxGraphModel>
   </diagram>
-  <diagram name="S3通行不可2" id="GofOoyZXz3otkXVmYKWo">
-    <mxGraphModel dx="323" dy="216" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+  <diagram name="pattern4" id="GofOoyZXz3otkXVmYKWo">
+    <mxGraphModel dx="984" dy="718" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
       <root>
         <mxCell id="AQSeIR6S58tue8VEiecH-0" />
         <mxCell id="AQSeIR6S58tue8VEiecH-1" parent="AQSeIR6S58tue8VEiecH-0" />
-        <mxCell id="AQSeIR6S58tue8VEiecH-2" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="AQSeIR6S58tue8VEiecH-1">
+        <mxCell id="AQSeIR6S58tue8VEiecH-2" value="" style="rounded=0;whiteSpace=wrap;html=1;" parent="AQSeIR6S58tue8VEiecH-1" vertex="1">
           <mxGeometry x="430" y="140" width="60" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-3" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="AQSeIR6S58tue8VEiecH-1">
+        <mxCell id="AQSeIR6S58tue8VEiecH-3" value="" style="rounded=0;whiteSpace=wrap;html=1;" parent="AQSeIR6S58tue8VEiecH-1" vertex="1">
           <mxGeometry x="430" width="60" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-4" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;fillColor=#e51400;strokeColor=#B20000;" edge="1" parent="AQSeIR6S58tue8VEiecH-1">
+        <mxCell id="AQSeIR6S58tue8VEiecH-4" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;fillColor=#e51400;strokeColor=#B20000;" parent="AQSeIR6S58tue8VEiecH-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="400" y="100" as="sourcePoint" />
             <mxPoint x="520" y="100" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-5" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="AQSeIR6S58tue8VEiecH-1">
+        <mxCell id="AQSeIR6S58tue8VEiecH-5" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="AQSeIR6S58tue8VEiecH-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="440" y="60" as="sourcePoint" />
             <mxPoint x="480" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-6" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="AQSeIR6S58tue8VEiecH-1" source="AQSeIR6S58tue8VEiecH-24">
+        <mxCell id="AQSeIR6S58tue8VEiecH-6" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="AQSeIR6S58tue8VEiecH-1" source="AQSeIR6S58tue8VEiecH-24" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="400" y="100" as="sourcePoint" />
             <mxPoint x="440" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-7" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="AQSeIR6S58tue8VEiecH-1" source="AQSeIR6S58tue8VEiecH-26">
+        <mxCell id="AQSeIR6S58tue8VEiecH-7" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="AQSeIR6S58tue8VEiecH-1" source="AQSeIR6S58tue8VEiecH-26" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="520" y="100" as="sourcePoint" />
             <mxPoint x="480" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-8" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="AQSeIR6S58tue8VEiecH-1">
+        <mxCell id="AQSeIR6S58tue8VEiecH-8" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="AQSeIR6S58tue8VEiecH-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="480" y="60" as="sourcePoint" />
             <mxPoint x="520" y="100" as="targetPoint" />
@@ -338,94 +483,94 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-9" value="j0a" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="AQSeIR6S58tue8VEiecH-1">
+        <mxCell id="AQSeIR6S58tue8VEiecH-9" value="j0a" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="AQSeIR6S58tue8VEiecH-1" vertex="1">
           <mxGeometry x="390" y="110" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-10" value="j0b" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="AQSeIR6S58tue8VEiecH-1">
+        <mxCell id="AQSeIR6S58tue8VEiecH-10" value="j0b" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="AQSeIR6S58tue8VEiecH-1" vertex="1">
           <mxGeometry x="420" y="20" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-11" value="j1a" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="AQSeIR6S58tue8VEiecH-1">
+        <mxCell id="AQSeIR6S58tue8VEiecH-11" value="j1a" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="AQSeIR6S58tue8VEiecH-1" vertex="1">
           <mxGeometry x="500" y="110" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-12" value="j1b" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="AQSeIR6S58tue8VEiecH-1">
+        <mxCell id="AQSeIR6S58tue8VEiecH-12" value="j1b" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="AQSeIR6S58tue8VEiecH-1" vertex="1">
           <mxGeometry x="460" y="20" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-13" value="s1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="AQSeIR6S58tue8VEiecH-1">
+        <mxCell id="AQSeIR6S58tue8VEiecH-13" value="s1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="AQSeIR6S58tue8VEiecH-1" vertex="1">
           <mxGeometry x="440" y="60" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-14" value="s2" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="AQSeIR6S58tue8VEiecH-1">
+        <mxCell id="AQSeIR6S58tue8VEiecH-14" value="s2" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="AQSeIR6S58tue8VEiecH-1" vertex="1">
           <mxGeometry x="600" y="70" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-15" value="s3" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="AQSeIR6S58tue8VEiecH-1">
+        <mxCell id="AQSeIR6S58tue8VEiecH-15" value="s3" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="AQSeIR6S58tue8VEiecH-1" vertex="1">
           <mxGeometry x="440" y="120" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-16" value="s4" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="AQSeIR6S58tue8VEiecH-1">
+        <mxCell id="AQSeIR6S58tue8VEiecH-16" value="s4" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="AQSeIR6S58tue8VEiecH-1" vertex="1">
           <mxGeometry x="380" y="70" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-17" value="s5" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="AQSeIR6S58tue8VEiecH-1">
+        <mxCell id="AQSeIR6S58tue8VEiecH-17" value="s5" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="AQSeIR6S58tue8VEiecH-1" vertex="1">
           <mxGeometry x="500" y="70" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-18" value="" style="endArrow=none;html=1;rounded=0;" edge="1" parent="AQSeIR6S58tue8VEiecH-1" source="AQSeIR6S58tue8VEiecH-21">
+        <mxCell id="AQSeIR6S58tue8VEiecH-18" value="" style="endArrow=none;html=1;rounded=0;" parent="AQSeIR6S58tue8VEiecH-1" source="AQSeIR6S58tue8VEiecH-21" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="370" y="60" as="sourcePoint" />
             <mxPoint x="440" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-19" value="" style="endArrow=none;html=1;rounded=0;" edge="1" parent="AQSeIR6S58tue8VEiecH-1">
+        <mxCell id="AQSeIR6S58tue8VEiecH-19" value="" style="endArrow=none;html=1;rounded=0;" parent="AQSeIR6S58tue8VEiecH-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="370" y="100" as="sourcePoint" />
             <mxPoint x="400" y="100" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-20" value="" style="endArrow=none;html=1;rounded=0;" edge="1" parent="AQSeIR6S58tue8VEiecH-1" target="AQSeIR6S58tue8VEiecH-21">
+        <mxCell id="AQSeIR6S58tue8VEiecH-20" value="" style="endArrow=none;html=1;rounded=0;" parent="AQSeIR6S58tue8VEiecH-1" target="AQSeIR6S58tue8VEiecH-21" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="370" y="60" as="sourcePoint" />
             <mxPoint x="440" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-21" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="AQSeIR6S58tue8VEiecH-1">
+        <mxCell id="AQSeIR6S58tue8VEiecH-21" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="AQSeIR6S58tue8VEiecH-1" vertex="1">
           <mxGeometry x="430" y="50" width="20" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-22" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="AQSeIR6S58tue8VEiecH-1">
+        <mxCell id="AQSeIR6S58tue8VEiecH-22" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="AQSeIR6S58tue8VEiecH-1" vertex="1">
           <mxGeometry x="470" y="50" width="20" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-23" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="AQSeIR6S58tue8VEiecH-1" target="AQSeIR6S58tue8VEiecH-24">
+        <mxCell id="AQSeIR6S58tue8VEiecH-23" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="AQSeIR6S58tue8VEiecH-1" target="AQSeIR6S58tue8VEiecH-24" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="400" y="100" as="sourcePoint" />
             <mxPoint x="440" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-24" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="AQSeIR6S58tue8VEiecH-1">
+        <mxCell id="AQSeIR6S58tue8VEiecH-24" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="AQSeIR6S58tue8VEiecH-1" vertex="1">
           <mxGeometry x="390" y="90" width="20" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-25" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="AQSeIR6S58tue8VEiecH-1" target="AQSeIR6S58tue8VEiecH-26">
+        <mxCell id="AQSeIR6S58tue8VEiecH-25" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="AQSeIR6S58tue8VEiecH-1" target="AQSeIR6S58tue8VEiecH-26" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="520" y="100" as="sourcePoint" />
             <mxPoint x="480" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-26" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="AQSeIR6S58tue8VEiecH-1">
+        <mxCell id="AQSeIR6S58tue8VEiecH-26" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="AQSeIR6S58tue8VEiecH-1" vertex="1">
           <mxGeometry x="510" y="90" width="20" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-27" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="AQSeIR6S58tue8VEiecH-1" source="AQSeIR6S58tue8VEiecH-21" target="AQSeIR6S58tue8VEiecH-21">
+        <mxCell id="AQSeIR6S58tue8VEiecH-27" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0;entryDx=0;entryDy=0;" parent="AQSeIR6S58tue8VEiecH-1" source="AQSeIR6S58tue8VEiecH-21" target="AQSeIR6S58tue8VEiecH-21" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="320" y="70" as="sourcePoint" />
             <mxPoint x="350" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-28" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=0;exitDx=0;exitDy=0;entryX=1;entryY=1;entryDx=0;entryDy=0;" edge="1" parent="AQSeIR6S58tue8VEiecH-1" target="AQSeIR6S58tue8VEiecH-22" source="AQSeIR6S58tue8VEiecH-22">
+        <mxCell id="AQSeIR6S58tue8VEiecH-28" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=0;exitDx=0;exitDy=0;entryX=1;entryY=1;entryDx=0;entryDy=0;" parent="AQSeIR6S58tue8VEiecH-1" source="AQSeIR6S58tue8VEiecH-22" target="AQSeIR6S58tue8VEiecH-22" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="470" y="60" as="sourcePoint" />
             <mxPoint x="490" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-29" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=1;exitY=0;exitDx=0;exitDy=0;entryX=0;entryY=1;entryDx=0;entryDy=0;" edge="1" parent="AQSeIR6S58tue8VEiecH-1" source="AQSeIR6S58tue8VEiecH-24" target="AQSeIR6S58tue8VEiecH-24">
+        <mxCell id="AQSeIR6S58tue8VEiecH-29" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=1;exitY=0;exitDx=0;exitDy=0;entryX=0;entryY=1;entryDx=0;entryDy=0;" parent="AQSeIR6S58tue8VEiecH-1" source="AQSeIR6S58tue8VEiecH-24" target="AQSeIR6S58tue8VEiecH-24" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="450" y="80" as="sourcePoint" />
             <mxPoint x="470" y="80" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="AQSeIR6S58tue8VEiecH-30" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=0;exitDx=0;exitDy=0;entryX=1;entryY=1;entryDx=0;entryDy=0;" edge="1" parent="AQSeIR6S58tue8VEiecH-1" source="AQSeIR6S58tue8VEiecH-26" target="AQSeIR6S58tue8VEiecH-26">
+        <mxCell id="AQSeIR6S58tue8VEiecH-30" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=0;exitDx=0;exitDy=0;entryX=1;entryY=1;entryDx=0;entryDy=0;" parent="AQSeIR6S58tue8VEiecH-1" source="AQSeIR6S58tue8VEiecH-26" target="AQSeIR6S58tue8VEiecH-26" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="510" y="99.82" as="sourcePoint" />
             <mxPoint x="530" y="99.82" as="targetPoint" />

--- a/ptcs/docs/ポイントの向き.drawio
+++ b/ptcs/docs/ポイントの向き.drawio
@@ -1,4 +1,4 @@
-<mxfile host="Electron" modified="2023-05-09T12:27:34.628Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/21.2.8 Chrome/112.0.5615.165 Electron/24.2.0 Safari/537.36" etag="FFpPNpK2nUJ9_qfxjfEp" version="21.2.8" type="device" pages="4">
+<mxfile host="Electron" modified="2023-05-09T13:50:21.777Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/21.2.8 Chrome/112.0.5615.165 Electron/24.2.0 Safari/537.36" etag="_OPYC6p5GSObmn6MSrZS" version="21.2.8" type="device" pages="4">
   <diagram name="pattern1" id="arh3FIw3pBXTjxhgvzi6">
     <mxGraphModel dx="984" dy="718" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
       <root>
@@ -145,41 +145,41 @@
     </mxGraphModel>
   </diagram>
   <diagram name="pattern2" id="spZ5XvLSFX5mMCUu9n3Z">
-    <mxGraphModel dx="984" dy="718" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+    <mxGraphModel dx="181" dy="132" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
       <root>
         <mxCell id="KMXKlcnqYH1HJKnBzze7-0" />
         <mxCell id="KMXKlcnqYH1HJKnBzze7-1" parent="KMXKlcnqYH1HJKnBzze7-0" />
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-2" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-2" value="" style="rounded=0;whiteSpace=wrap;html=1;" parent="KMXKlcnqYH1HJKnBzze7-1" vertex="1">
           <mxGeometry x="430" y="140" width="60" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-3" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-3" value="" style="rounded=0;whiteSpace=wrap;html=1;" parent="KMXKlcnqYH1HJKnBzze7-1" vertex="1">
           <mxGeometry x="430" width="60" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-4" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-4" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="KMXKlcnqYH1HJKnBzze7-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="400" y="100" as="sourcePoint" />
             <mxPoint x="520" y="100" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-5" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-5" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="KMXKlcnqYH1HJKnBzze7-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="440" y="60" as="sourcePoint" />
             <mxPoint x="480" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-6" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1" source="KMXKlcnqYH1HJKnBzze7-24">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-6" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="KMXKlcnqYH1HJKnBzze7-1" source="KMXKlcnqYH1HJKnBzze7-24" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="400" y="100" as="sourcePoint" />
             <mxPoint x="440" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-7" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1" source="KMXKlcnqYH1HJKnBzze7-26">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-7" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="KMXKlcnqYH1HJKnBzze7-1" source="KMXKlcnqYH1HJKnBzze7-26" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="520" y="100" as="sourcePoint" />
             <mxPoint x="480" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-8" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-8" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="KMXKlcnqYH1HJKnBzze7-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="480" y="60" as="sourcePoint" />
             <mxPoint x="520" y="100" as="targetPoint" />
@@ -193,94 +193,94 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-9" value="j0a" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-9" value="j0a" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="KMXKlcnqYH1HJKnBzze7-1" vertex="1">
           <mxGeometry x="390" y="110" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-10" value="j0b" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-10" value="j0b" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="KMXKlcnqYH1HJKnBzze7-1" vertex="1">
           <mxGeometry x="420" y="20" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-11" value="j1a" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-11" value="j1a" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="KMXKlcnqYH1HJKnBzze7-1" vertex="1">
           <mxGeometry x="500" y="110" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-12" value="j1b" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-12" value="j1b" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="KMXKlcnqYH1HJKnBzze7-1" vertex="1">
           <mxGeometry x="460" y="20" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-13" value="s1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-13" value="s1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="KMXKlcnqYH1HJKnBzze7-1" vertex="1">
           <mxGeometry x="440" y="60" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-14" value="s2" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-14" value="s2" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="KMXKlcnqYH1HJKnBzze7-1" vertex="1">
           <mxGeometry x="600" y="70" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-15" value="s3" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-15" value="s3" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="KMXKlcnqYH1HJKnBzze7-1" vertex="1">
           <mxGeometry x="440" y="120" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-16" value="s4" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-16" value="s4" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="KMXKlcnqYH1HJKnBzze7-1" vertex="1">
           <mxGeometry x="380" y="70" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-17" value="s5" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-17" value="s5" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontFamily=Lucida Console;" parent="KMXKlcnqYH1HJKnBzze7-1" vertex="1">
           <mxGeometry x="500" y="70" width="40" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-18" value="" style="endArrow=none;html=1;rounded=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1" source="KMXKlcnqYH1HJKnBzze7-21">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-18" value="" style="endArrow=none;html=1;rounded=0;" parent="KMXKlcnqYH1HJKnBzze7-1" source="KMXKlcnqYH1HJKnBzze7-21" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="370" y="60" as="sourcePoint" />
             <mxPoint x="440" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-19" value="" style="endArrow=none;html=1;rounded=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-19" value="" style="endArrow=none;html=1;rounded=0;" parent="KMXKlcnqYH1HJKnBzze7-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="370" y="100" as="sourcePoint" />
             <mxPoint x="400" y="100" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-20" value="" style="endArrow=none;html=1;rounded=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1" target="KMXKlcnqYH1HJKnBzze7-21">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-20" value="" style="endArrow=none;html=1;rounded=0;" parent="KMXKlcnqYH1HJKnBzze7-1" target="KMXKlcnqYH1HJKnBzze7-21" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="370" y="60" as="sourcePoint" />
             <mxPoint x="440" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-21" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-21" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="KMXKlcnqYH1HJKnBzze7-1" vertex="1">
           <mxGeometry x="430" y="50" width="20" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-22" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-22" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="KMXKlcnqYH1HJKnBzze7-1" vertex="1">
           <mxGeometry x="470" y="50" width="20" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-23" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1" target="KMXKlcnqYH1HJKnBzze7-24">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-23" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="KMXKlcnqYH1HJKnBzze7-1" target="KMXKlcnqYH1HJKnBzze7-24" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="400" y="100" as="sourcePoint" />
             <mxPoint x="440" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-24" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-24" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="KMXKlcnqYH1HJKnBzze7-1" vertex="1">
           <mxGeometry x="390" y="90" width="20" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-25" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1" target="KMXKlcnqYH1HJKnBzze7-26">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-25" value="" style="endArrow=baseDash;html=1;rounded=0;startArrow=baseDash;startFill=0;endFill=0;" parent="KMXKlcnqYH1HJKnBzze7-1" target="KMXKlcnqYH1HJKnBzze7-26" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="520" y="100" as="sourcePoint" />
             <mxPoint x="480" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-26" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-26" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="KMXKlcnqYH1HJKnBzze7-1" vertex="1">
           <mxGeometry x="510" y="90" width="20" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-27" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1" source="KMXKlcnqYH1HJKnBzze7-21" target="KMXKlcnqYH1HJKnBzze7-21">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-27" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0;entryDx=0;entryDy=0;" parent="KMXKlcnqYH1HJKnBzze7-1" source="KMXKlcnqYH1HJKnBzze7-21" target="KMXKlcnqYH1HJKnBzze7-21" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="320" y="70" as="sourcePoint" />
             <mxPoint x="350" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-28" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-28" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" parent="KMXKlcnqYH1HJKnBzze7-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="470" y="60" as="sourcePoint" />
             <mxPoint x="490" y="60" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-29" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=1;exitY=0;exitDx=0;exitDy=0;entryX=0;entryY=1;entryDx=0;entryDy=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1" source="KMXKlcnqYH1HJKnBzze7-24" target="KMXKlcnqYH1HJKnBzze7-24">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-29" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=1;exitY=0;exitDx=0;exitDy=0;entryX=0;entryY=1;entryDx=0;entryDy=0;" parent="KMXKlcnqYH1HJKnBzze7-1" source="KMXKlcnqYH1HJKnBzze7-24" target="KMXKlcnqYH1HJKnBzze7-24" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="450" y="80" as="sourcePoint" />
             <mxPoint x="470" y="80" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="KMXKlcnqYH1HJKnBzze7-30" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="KMXKlcnqYH1HJKnBzze7-1">
+        <mxCell id="KMXKlcnqYH1HJKnBzze7-30" value="" style="endArrow=none;html=1;rounded=0;fillColor=#e51400;strokeColor=#0000FF;strokeWidth=2;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" parent="KMXKlcnqYH1HJKnBzze7-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="510" y="99.82" as="sourcePoint" />
             <mxPoint x="530" y="99.82" as="targetPoint" />

--- a/ptcs/ptcs_control/control.py
+++ b/ptcs/ptcs_control/control.py
@@ -136,15 +136,15 @@ class Control:
         s3_blocked: bool = self.state.sections[s3].blocked
 
         train_states = self.state.trains
-        # s1にtarget_junctionがj1bであるtrainが存在するか
-        s1_j1b_exist: bool = False
+        # s1にtarget_junctionがj0bであるtrainが存在するか
+        s1_j0b_exist: bool = False
         # s2に列車が存在するか
         s2_exist: bool = False
         # s5にtrainが存在するか
         s5_exist: bool = False
         for train_state in train_states.values():
-            if train_state.current_section == s1 and train_state.target_junction == j1b:
-                s1_j1b_exist = True
+            if train_state.current_section == s1 and train_state.target_junction == j0b:
+                s1_j0b_exist = True
             if train_state.current_section == s2:
                 s2_exist = True
             if train_state.current_section == s5:
@@ -154,10 +154,10 @@ class Control:
         junction_direction: list[tuple[Junction, Direction]]
         if not s3_blocked:
             junction_direction = possible_junction_direction["normal"]
-        elif s1_j1b_exist or (not s2_exist and not s5_exist):
-            junction_direction = possible_junction_direction["blocked1"]
-        elif not s1_j1b_exist and (s2_exist or s5_exist):
+        elif s1_j0b_exist or s2_exist or s5_exist:
             junction_direction = possible_junction_direction["blocked2"]
+        else:
+            junction_direction = possible_junction_direction["blocked1"]
 
         # ポイント変更
         for junction_id, direction in junction_direction:

--- a/ptcs/ptcs_control/control.py
+++ b/ptcs/ptcs_control/control.py
@@ -114,18 +114,23 @@ class Control:
         s1 = Section("s1")
         s2 = Section("s2")
         s3 = Section("s3")
+        s4 = Section("s4")
         s5 = Section("s5")
         # 「とりうるルート」の列挙
         possible_junction_direction: dict[str, list[tuple[Junction, Direction]]] = {
-            "normal": [(j0a, Direction.STRAIGHT),
+            "pattern1": [(j0a, Direction.STRAIGHT),
                        (j0b, Direction.STRAIGHT),
                        (j1a, Direction.STRAIGHT),
                        (j1b, Direction.STRAIGHT)],
-            "blocked1": [(j0a, Direction.CURVE),
+            "pattern2": [(j0a, Direction.CURVE),
+                       (j0b, Direction.CURVE),
+                       (j1a, Direction.STRAIGHT),
+                       (j1b, Direction.STRAIGHT)],
+            "pattern3": [(j0a, Direction.CURVE),
                          (j0b, Direction.STRAIGHT),
                          (j1a, Direction.CURVE),
                          (j1b, Direction.STRAIGHT)],
-            "blocked2": [(j0a, Direction.CURVE),
+            "pattern4": [(j0a, Direction.CURVE),
                          (j0b, Direction.CURVE),
                          (j1a, Direction.CURVE),
                          (j1b, Direction.CURVE)]
@@ -138,27 +143,43 @@ class Control:
         train_states = self.state.trains
         # s1にtarget_junctionがj0bであるtrainが存在するか
         s1_j0b_exist: bool = False
-        # s2に列車が存在するか
-        s2_exist: bool = False
+        # s1にtarget_junctionがj1bであるtrainが存在するか
+        s1_j1b_exist: bool = False
+        # s4にtrainが存在するか
+        s4_exist: bool = False
         # s5にtrainが存在するか
         s5_exist: bool = False
         for train_state in train_states.values():
             if train_state.current_section == s1 and train_state.target_junction == j0b:
                 s1_j0b_exist = True
-            if train_state.current_section == s2:
-                s2_exist = True
+            if train_state.current_section == s1 and train_state.target_junction == j1b:
+                s1_j1b_exist = True
+            if train_state.current_section == s4:
+                s4_exist = True
             if train_state.current_section == s5:
                 s5_exist = True
 
         # ポイントの向きを判定
         junction_direction: list[tuple[Junction, Direction]]
-        if not s3_blocked:
-            junction_direction = possible_junction_direction["normal"]
-        elif s1_j0b_exist or s2_exist or s5_exist:
-            junction_direction = possible_junction_direction["blocked2"]
+        if s3_blocked:
+            if not s1_j0b_exist and (s1_j1b_exist or not s5_exist):
+                junction_direction = possible_junction_direction["pattern3"]
+            elif s1_j0b_exist or (not s1_j1b_exist and s5_exist):
+                junction_direction = possible_junction_direction["pattern4"]
+            else:
+                raise
         else:
-            junction_direction = possible_junction_direction["blocked1"]
-
+            if not s1_j0b_exist and not s4_exist and not s5_exist:
+                junction_direction = possible_junction_direction["pattern1"]
+            elif (s1_j0b_exist or s4_exist) and not s5_exist:
+                junction_direction = possible_junction_direction["pattern2"]
+            elif not s1_j0b_exist and (s1_j1b_exist or not s5_exist):
+                junction_direction = possible_junction_direction["pattern3"]
+            elif not s1_j1b_exist and s5_exist:
+                junction_direction = possible_junction_direction["pattern4"]
+            else: 
+                raise
+        
         # ポイント変更
         for junction_id, direction in junction_direction:
             self.update_junction(junction_id=junction_id, direction=direction)


### PR DESCRIPTION
#6 で考えていたとりうるルートとその向きがよろしくないので修正する

# 取りうるルート
取りうるルートと、そのルートを使うタイミングは以下の通り（のはず）

trainは物理的には長さがあるため、sectionを跨ぐタイミングでcurrent_sectionで取得したsection以外にもtrainが存在することがありそうなので、これでうまくいくのか？という感じはあります。

## pattern1
![ポイントの向き-通常時 drawio](https://user-images.githubusercontent.com/55520073/236625713-047be959-9b4b-4e36-a600-3e59b299d6f8.png)

- s3がblocked
  - なし
- s3がunblocked
  - s1にtarget_junctionがj0bであるtrainが存在しない時、かつ、s4にtrainが存在しない時、かつ、s5にtrainが存在しない時

## pattern2
![ポイントの向き-pattern2 drawio](https://github.com/plarailers/gogatsusai2023/assets/55520073/0be42cc7-fa57-41b3-8576-6a6c1918f5a5)
- s3がblocked
  - なし
- s3がunblocked
  - （s1にtarget_junctionがj0bであるtrainが存在する時、または、s4にtrainが存在する時）、かつ、s5にtrainが存在しない時

## pattern3
![ポイントの向き-S3通行不可1 drawio](https://user-images.githubusercontent.com/55520073/236625762-364aa547-0ebf-40d0-b882-999b05b0b6b3.png)

- s3がblocked
  - s1にtarget_junctionがj0bであるtrainが存在しない時、かつ、（s1にtarget_junctionがj1bであるtrainが存在する時、または、s5にtrainが存在しない時）
- s3がunblocked
  - s1にtarget_junctionがj0bであるtrainが存在しない時、かつ、（s1にtarget_junctionがj1bであるtrainが存在する時、または、s5にtrainが存在しない時）

## pattern4
![ポイントの向き-S3通行不可2 drawio](https://user-images.githubusercontent.com/55520073/236625808-0bc26406-59b9-4886-a1fd-684452082919.png)

- s3がblocked
  - s1にtarget_junctionがj0bであるtrainが存在する時、または、(s1にtarget_junctionがj1bであるtrainが存在しない時、かつ、s5にtrainが存在する時)
- s3がunblocked
  - s1にtarget_junctionがj1bであるtrainが存在しない時、かつ、s5にtrainが存在する時

# 動作確認
<img width="975" alt="スクリーンショット 2023-05-09 19 20 11" src="https://github.com/plarailers/gogatsusai2023/assets/55520073/b0e9e390-087e-4732-b8ba-ec1300f3f10e">
上手くいってそう
