### PR TITLE
速度指令値を motor input に変換する

### DIFF
--- a/ptcs/ptcs_control/control.py
+++ b/ptcs/ptcs_control/control.py
@@ -61,6 +61,14 @@ class Control:
 
         self.state.junctions[junction_id].direction = direction
 
+    def move_train_mr(self, train_id: "Train", motor_rotation: int) -> None:
+        """
+        指定された列車をモータ motor_rotation 回転分だけ進める
+        """
+
+        delta_per_motor_rotation = self.config.trains[train_id].delta_per_motor_rotation
+        self.move_train(train_id, motor_rotation * delta_per_motor_rotation)
+
     def move_train(self, train_id: "Train", delta: float) -> None:
         """
         指定された列車を距離 delta 分だけ進める。

--- a/ptcs/ptcs_control/railway_config.py
+++ b/ptcs/ptcs_control/railway_config.py
@@ -51,9 +51,11 @@ class RailwayConfig(BaseModel):
                 length=length,
             )
 
-    def define_trains(self, *train_tuples: tuple["Train"]) -> None:
-        for (train_id,) in train_tuples:
-            self.trains[train_id] = TrainConfig()
+    def define_trains(self, *train_tuples: tuple["Train", int, int, float]) -> None:
+        for train_id, min_input, max_input, max_speed in train_tuples:
+            self.trains[train_id] = TrainConfig(
+                min_input=min_input, max_input=max_input, max_speed=max_speed
+            )
 
 
 class JunctionConfig(BaseModel):
@@ -78,7 +80,20 @@ class SectionConfig(BaseModel):
 
 
 class TrainConfig(BaseModel):
-    pass
+    min_input: int
+    max_input: int
+    max_speed: float
+
+    def get_input_from_speed(self, speed: float) -> int:
+        if speed > self.max_speed:
+            return self.max_input
+        elif speed <= 0:
+            return 0
+        else:
+            return (
+                self.min_input
+                + (self.max_input - self.min_input) * speed / self.max_speed
+            )
 
 
 class StationConfig(BaseModel):
@@ -138,8 +153,8 @@ def init_config() -> RailwayConfig:
     )
 
     config.define_trains(
-        (t0,),
-        (t1,),
+        (t0, 70, 110, 40.0),  # Train, min_input, max_input, max_speed
+        (t1, 70, 110, 40.0),  # Train, min_input, max_input, max_speed
     )
 
     config.stations.update(

--- a/ptcs/ptcs_control/railway_config.py
+++ b/ptcs/ptcs_control/railway_config.py
@@ -96,7 +96,7 @@ class TrainConfig(BaseModel):
     max_speed: float
     delta_per_motor_rotation: float  # モータ1回転で進む距離[cm]
 
-    def get_input_from_speed(self, speed: float) -> int:
+    def calc_input(self, speed: float) -> int:
         if speed > self.max_speed:
             return self.max_input
         elif speed <= 0:

--- a/ptcs/ptcs_control/railway_config.py
+++ b/ptcs/ptcs_control/railway_config.py
@@ -51,10 +51,21 @@ class RailwayConfig(BaseModel):
                 length=length,
             )
 
-    def define_trains(self, *train_tuples: tuple["Train", int, int, float]) -> None:
-        for train_id, min_input, max_input, max_speed in train_tuples:
+    def define_trains(
+        self, *train_tuples: tuple["Train", int, int, float, float]
+    ) -> None:
+        for (
+            train_id,
+            min_input,
+            max_input,
+            max_speed,
+            delta_per_motor_rotation,
+        ) in train_tuples:
             self.trains[train_id] = TrainConfig(
-                min_input=min_input, max_input=max_input, max_speed=max_speed
+                min_input=min_input,
+                max_input=max_input,
+                max_speed=max_speed,
+                delta_per_motor_rotation=delta_per_motor_rotation,
             )
 
 
@@ -83,6 +94,7 @@ class TrainConfig(BaseModel):
     min_input: int
     max_input: int
     max_speed: float
+    delta_per_motor_rotation: float  # モータ1回転で進む距離[cm]
 
     def get_input_from_speed(self, speed: float) -> int:
         if speed > self.max_speed:
@@ -153,8 +165,8 @@ def init_config() -> RailwayConfig:
     )
 
     config.define_trains(
-        (t0, 70, 110, 40.0),  # Train, min_input, max_input, max_speed
-        (t1, 70, 110, 40.0),  # Train, min_input, max_input, max_speed
+        (t0, 70, 110, 40.0, 0.3),
+        (t1, 70, 110, 40.0, 0.3),
     )
 
     config.stations.update(

--- a/ptcs/ptcs_server/server.py
+++ b/ptcs/ptcs_server/server.py
@@ -31,8 +31,8 @@ def create_app_with_bridge() -> FastAPI:
     def handle_receive(target: BridgeTarget, data: Any) -> None:
         print(target, data)
         # TODO: インターフェイスを定めてコマンドを判別する
-        if data["pID"]:
-            control.move_train(target, data["wR"] / 100)
+        if data["mR"]:
+            control.move_train_mr(target, data["mR"])
 
     bridges = BridgeManager(callback=handle_receive)
 


### PR DESCRIPTION
## 目的
システム上で計算した速度指令値[cm/s]を、0～255 の motor input `mI` に換算してESP32に送信する必要がある。その換算を行う関数を実装する

## プロパティ
`TrainConfig`に、以下のプロパティを設けた

| name | type | 説明 |
|---|---|---|
|`min_input`|int|列車が動き出す最低の motor input|
|`max_input`|int|列車に与える最大の motor input|
|`max_speed`|float|最高速度。前回システムを踏襲し 40cm/s 程度|
|`delta_per_motor_rotation`|float|モータ1回転で進む距離[cm]。列車から送られてくる `mR` を cm に換算するために使う|

## マージ
レビュー後勝手にマージして問題ありません