### PR TITLE
Feature/avoid toggle when passing

### DIFF
--- a/ptcs/ptcs_control/control.py
+++ b/ptcs/ptcs_control/control.py
@@ -191,7 +191,48 @@ class Control:
 
         # ポイント変更
         for junction_id, direction in junction_direction:
-            self.update_junction(junction_id=junction_id, direction=direction)
+            if not self.junction_toggle_prohibited(junction_id):
+                self.update_junction(junction_id=junction_id, direction=direction)
+
+    def junction_toggle_prohibited(self, junction_id: "Junction") -> bool:
+        """
+        指定されたjunctionを列車が通過中であり、切り替えてはいけない場合にTrueを返す
+        """
+
+        MERGIN: float = 10  # ポイント通過後すぐに切り替えるとまずいので余裕距離をとる
+        TRAIN_LENGTH: float = 40  # 列車の長さ[cm] NOTE: 将来的には車両等のパラメータとして外に出す
+
+        for train_id, train_state in self.state.trains.items():
+
+            # 列車の最後尾からMERGIN離れた位置(tail_section, tail_mileage, tail_target_junction)を取得
+            current_section_config = self.config.sections[train_state.current_section]
+            (
+                tail_section,
+                tail_mileage,
+                tail_target_junction_opposite,
+            ) = self._get_new_position(
+                train_state.current_section,
+                train_state.mileage,
+                current_section_config.get_opposite_junction(  # 進行方向と反対向きにたどる
+                    train_state.target_junction
+                ),
+                TRAIN_LENGTH + MERGIN,
+            )
+            tail_section_config = self.config.sections[tail_section]
+            tail_target_junction = tail_section_config.get_opposite_junction(
+                tail_target_junction_opposite  # 進行方向と反対のjunctionなので元に戻す
+            )
+
+            # 列車の先頭は指定されたjunctionに向かっていないが、
+            # 列車の最後尾は指定されたjunctionに向かっている場合、
+            # 列車はそのjunctinoを通過中なので、切り替えを禁止する
+            if (
+                train_state.target_junction != junction_id
+                and tail_target_junction == junction_id
+            ):
+                return True
+
+        return False  # 誰も通過していなければFalseを返す
 
     def calc_speed(self) -> None:
         BREAK_ACCLT: float = 10  # ブレーキ減速度[cm/s/s]  NOTE:将来的には車両のパラメータとして定義
@@ -295,14 +336,14 @@ class Control:
             if speedlimit > MAX_SPEED:
                 speedlimit = MAX_SPEED
 
-            print(
-                train_id,
-                self._get_forward_train(train_id),
-                self._get_next_section_and_junction_strict(
-                    train_state.current_section, train_state.target_junction
-                ),
-                distance,
-            )
+            # print(
+            #     train_id,
+            #     self._get_forward_train(train_id),
+            #     self._get_next_section_and_junction_strict(
+            #         train_state.current_section, train_state.target_junction
+            #     ),
+            #     distance,
+            # )
 
             # [ATO]停車駅の情報から、停止位置を取得する
             # [ATO]ATPで計算した許容速度の範囲内で、停止位置で止まるための速度を計算する

--- a/ptcs/ptcs_control/control.py
+++ b/ptcs/ptcs_control/control.py
@@ -119,22 +119,30 @@ class Control:
         s5 = Section("s5")
         # 「とりうるルート」の列挙
         possible_junction_direction: dict[str, list[tuple[Junction, Direction]]] = {
-            "pattern1": [(j0a, Direction.STRAIGHT),
-                       (j0b, Direction.STRAIGHT),
-                       (j1a, Direction.STRAIGHT),
-                       (j1b, Direction.STRAIGHT)],
-            "pattern2": [(j0a, Direction.CURVE),
-                       (j0b, Direction.CURVE),
-                       (j1a, Direction.STRAIGHT),
-                       (j1b, Direction.STRAIGHT)],
-            "pattern3": [(j0a, Direction.CURVE),
-                         (j0b, Direction.STRAIGHT),
-                         (j1a, Direction.CURVE),
-                         (j1b, Direction.STRAIGHT)],
-            "pattern4": [(j0a, Direction.CURVE),
-                         (j0b, Direction.CURVE),
-                         (j1a, Direction.CURVE),
-                         (j1b, Direction.CURVE)]
+            "pattern1": [
+                (j0a, Direction.STRAIGHT),
+                (j0b, Direction.STRAIGHT),
+                (j1a, Direction.STRAIGHT),
+                (j1b, Direction.STRAIGHT),
+            ],
+            "pattern2": [
+                (j0a, Direction.CURVE),
+                (j0b, Direction.CURVE),
+                (j1a, Direction.STRAIGHT),
+                (j1b, Direction.STRAIGHT),
+            ],
+            "pattern3": [
+                (j0a, Direction.CURVE),
+                (j0b, Direction.STRAIGHT),
+                (j1a, Direction.CURVE),
+                (j1b, Direction.STRAIGHT),
+            ],
+            "pattern4": [
+                (j0a, Direction.CURVE),
+                (j0b, Direction.CURVE),
+                (j1a, Direction.CURVE),
+                (j1b, Direction.CURVE),
+            ],
         }
 
         # 列車位置と線路の状態（障害物の有無）に応じてどのルートを使うか判断する
@@ -178,9 +186,9 @@ class Control:
                 junction_direction = possible_junction_direction["pattern3"]
             elif not s1_j1b_exist and s5_exist:
                 junction_direction = possible_junction_direction["pattern4"]
-            else: 
+            else:
                 raise
-        
+
         # ポイント変更
         for junction_id, direction in junction_direction:
             self.update_junction(junction_id=junction_id, direction=direction)


### PR DESCRIPTION
ぱっと見うまくうごくと思う

![avoid-toggle-when-passing](https://github.com/plarailers/gogatsusai2023/assets/61099832/5a13af4b-0cf6-48b7-9d0c-f2b3a97a5b02)

## あらたに生じた問題点
blockされたセクションにいる列車に対して、calc_speedは「ただちにspeedを0にする」という実装をしている。もし入口ジャンクション`j1a`を通過中にblockされた場合、当該通過列車が即時停止するので、入口ジャンクションを永久にふさいでしまう。これは後で解決してもよいが、さしあたりそういう仕様でもよい気がする（普通に考えて、駅で飛来物があったら、飛来物を撤去して安全の確認が取れるまで運転再開しないと思う）