### PR TITLE
calc_speedに停止目標の結果を反映

### DIFF
--- a/ptcs/ptcs_control/railway_state.py
+++ b/ptcs/ptcs_control/railway_state.py
@@ -60,6 +60,7 @@ class TrainState(BaseModel):
     target_junction: "Junction"
     mileage: float
     stop: Optional["Stop"] = Field(default=None, description="列車の停止目標")
+    stop_distance: Optional[float] = Field(default=0, description="停止目標までの距離[cm]")
     departure_time: Optional[int] = Field(default=None, description="発車予定時刻")
 
 


### PR DESCRIPTION
停止目標 Stop の計算結果をもとに calc_speed を実施するよう更新しました。列車が駅で止まれるようになりました。

## 悩ましい点
- calc_stop で計算した停止目標までの距離も、TrainState のプロパティとして入れてしまいました（このほうが楽なので……。本当は、calc_speed の中で calc_stop を実行すべきなのかもしれない）

## マージについて
必要であれば勝手にマージしてもらって大丈夫です