### PR TITLE
PointSwitcherManager.registerの引数の取り方の順番の修正

### DIFF
--- a/ptcs/ptcs_server/points.py
+++ b/ptcs/ptcs_server/points.py
@@ -47,7 +47,7 @@ class PointSwitcherManager:
         for key, value in self.points.items():
             print(f"  {key} = {value}")
 
-    def register(self, target: PointTarget, servo_no: int, point_switcher: PointSwitcher) -> None:
+    def register(self, target: PointTarget, point_switcher: PointSwitcher, servo_no: int) -> None:
         """
         ポイントを登録する。
         """


### PR DESCRIPTION
self, target: PointTarget, servo_no: int, point_switcher: PointSwitcher

の順だったのを

self, target: PointTarget, point_switcher: PointSwitcher, servo_no: int

に変更

参考：https://github.com/plarailers/gogatsusai2023/pull/21#issuecomment-1544091677