### PR TITLE
すでにblockされたsectionに入っている列車は駅で止める

### DIFF
--- a/ptcs/ptcs_server/api.py
+++ b/ptcs/ptcs_server/api.py
@@ -95,6 +95,10 @@ def block_section(section_id: str, request: Request) -> None:
     control.block_section(section)
     # calc_directionデバック用
     control.calc_direction()
+    # calc_stopデバック用
+    control.calc_stop()
+    # calc_speedデバック用
+    control.calc_speed()
 
 
 @api_router.post("/state/sections/{section_id}/unblock")
@@ -108,3 +112,7 @@ def unblock_section(section_id: str, request: Request) -> None:
     control.unblock_section(section)
     # calc_directionデバック用
     control.calc_direction()
+    # calc_stopデバック用
+    control.calc_stop()
+    # calc_speedデバック用
+    control.calc_speed()


### PR DESCRIPTION
## もくてき
- タイトルの通りです。駅に飛来物が飛んできたとき、駅入口にある junction を通過中の列車を即時止めてしまうと junction を塞いでしまいます。これを防ぐために `calc_speed()` 関数を修正して、駅の停止位置まで進むようにします。
  - #19 で指摘されていた問題点を解消した形になります。
- 動作確認は、import エラーで動かなくなる前の main を使って行いました。

## 付随する変更点
- `calc_stop()` で停止位置までの距離を返す部分を意図が分かりやすいよう若干修正していますが、ロジック的変更はないはずです。
- blockSection, unblockSection 実行後にも、direction, stop, speed すべてを再計算するようにしました。

## 新たに生じた問題点
`calc_stop()` 関数が駅の停車時間を判断する際、
```python
# 停止目標を過ぎたとき（異なる）
# 停止目標を見失ったとき（not None → None）
```
とありますが、blockSection によって junction の方向が再計算されたときにも停止目標を見失う場合があります。このとき、`calc_stop()` が駅に着いたと誤認して列車を止めてしまいます。ただ、駅到着によって停止目標を見失う場合との区別が難しいので、いったん無視します。
- お客さん的にも、「ああ飛来物があったからいったん停車して仕切り直すんだな」と説明すれば文句はないでしょう。