### PR TITLE
通信不安定現象の改善(システム側)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.vscode
 *.vscode/*
 __pycache__/
+build

--- a/pc_changable/Usb_bt_bridge/Usb_bt_bridge.ino
+++ b/pc_changable/Usb_bt_bridge/Usb_bt_bridge.ino
@@ -2,72 +2,42 @@
 #include "BluetoothSerial.h"
 
 BluetoothSerial SerialBT;
-// Bluetooth受信(Receiver)側のMacアドレスを設定する。
-//String MACadd = "9C:9C:1F:CB:D9:F2";
-//uint8_t address[6]  = {0x9C, 0x9C, 0x1F, 0xCB, 0xD9, 0xF2};
-bool connected;
+
+bool connected = false;
 const int BUFFER_SIZE = 32;
 char buf[BUFFER_SIZE];
 char buf2[BUFFER_SIZE];
 
 void setup() {
+    Serial.begin(115200);
+    SerialBT.begin("ESP32_sender", true); 
+    //上のtrueはmasterであることを示す
 
-  pinMode( 5, OUTPUT);
-  Serial.begin(115200);
-  SerialBT.begin("ESP32_sender", true); 
-  //上のtrueはmasterであることを示す
-  connected = SerialBT.connect("ESP32_receiver");
-  //addressはname or Macaddressを引数にとる。前者はmax30ms後者はmax10ms程度の秒数で接続可能
-  /*
-  if(connected){
-    Serial.println("Connected Succesfully!");
-  }else {
-    while(!SerialBT.connected(10000)) {
-      Serial.println("Failed to connect. Make sure remote device is available and in range, then restart app."); 
+    while (!connected) {
+        Serial.println("Connecting...");
+        connected = SerialBT.connect("ESP32-E5");
+        //addressはname or Macaddressを引数にとる。前者はmax30ms後者はmax10ms程度の秒数で接続可能
+
+        if(connected){
+            Serial.println("Connected Succesfully!");
+        }
+        else {
+            Serial.println("Failed to connect. Make sure remote device is available and in range, then restart app."); 
+        }
     }
-  }
-  */
+  
 }
 
 void loop() {  
-  // pythonから受信し、ESP32に送信
-  int index=0;
-  while(Serial.available()>0){
-      buf[index] = Serial.read();
-      delay(2);
-      if(buf[index]=='}'){
-        break;
-      }
-      if (index+1 >= BUFFER_SIZE) {
-        break;
-      }
-      index++;
-  }
-  for(int i = 0; i <= index; i++){
-      SerialBT.write(buf[i]);//データをそのまま送信
+    // pythonから受信し、ESP32に送信
+    while(Serial.available()>0){
+        char sendData = Serial.read();
+        SerialBT.write(sendData);
     }
 
-  memset(buf, '\0', BUFFER_SIZE);
-  index=0;
-
-  // ESP32から受信し、pythonに送信
-  while(SerialBT.available()>0) {
-    buf2[index] = SerialBT.read();
-    delay(2);
-    if(buf2[index]=='}'){
-      break;
+    // ESP32から受信し、pythonに送信
+    while(SerialBT.available()>0) {
+        char recvData = SerialBT.read();
+        Serial.write(recvData);
     }
-    if (index+1 >= BUFFER_SIZE) {
-      break;
-    }
-    index++;
-  }
-  for(int i = 0; i <= index; i++){
-      Serial.write(buf2[i]);
-    }
-
-  memset(buf2, '\0', BUFFER_SIZE);
-  index=0;
-
-  delay(300);
 }

--- a/ptcs/ptcs_control/railway_config.py
+++ b/ptcs/ptcs_control/railway_config.py
@@ -1,3 +1,4 @@
+import math
 from pydantic import BaseModel, Field
 from .components import Joint, Junction, Position, Section, Station, Stop, Train
 from .constants import (
@@ -110,7 +111,7 @@ class TrainConfig(BaseModel):
         elif speed <= 0:
             return 0
         else:
-            return (
+            return math.floor(
                 self.min_input
                 + (self.max_input - self.min_input) * speed / self.max_speed
             )

--- a/ptcs/ptcs_server/bridges.py
+++ b/ptcs/ptcs_server/bridges.py
@@ -19,14 +19,16 @@ class BridgeManager:
     positions: PositionDict
     send_queue: queue.Queue[tuple[BridgeTarget, Any]]
     callback: BridgeCallback
-    thread: Optional[threading.Thread]
+    send_thread: Optional[threading.Thread]
+    recv_thread: Optional[threading.Thread]
 
     def __init__(self, callback: BridgeCallback) -> None:
         self.bridges = {}
         self.positions = {}
         self.send_queue = queue.Queue()
         self.callback = callback
-        self.thread = None
+        self.send_thread = None
+        self.recv_thread = None
 
     def print_ports(self) -> None:
         print("ports:")
@@ -56,38 +58,45 @@ class BridgeManager:
 
     def start(self) -> None:
         """
-        送受信スレッドを開始する。
+        送信スレッドと受信スレッドを開始する。
         """
-        thread = threading.Thread(target=self._run, daemon=True)
-        thread.start()
-        self.thread = thread
+        send_thread = threading.Thread(target=self._run_send, daemon=True)
+        send_thread.start()
+        self.send_thread = send_thread
 
-    def _run(self) -> None:
+        recv_thread = threading.Thread(target=self._run_recv, daemon=True)
+        recv_thread.start()
+        self.recv_thread = recv_thread
+
+    def _run_send(self) -> None:
         """
-        スレッドの中身。
-        ブリッジから受信したデータがあれば、コールバックを呼び出す。
+        送信スレッドの中身。
         送信キューにデータがあれば、ブリッジに送信する。
         """
 
         while True:
-            # 受信
+            target, data = self.send_queue.get()  # ブロッキング処理
+            logging.info(f"SEND {target} {data}")
+            bridge = self.bridges[target]
+            message = json.dumps(data)
+            bridge.send(message)
+
+    def _run_recv(self) -> None:
+        """
+        受信スレッドの中身。
+        ブリッジから受信したデータがあれば、コールバックを呼び出す。
+        """
+
+        while True:
             for target, bridge in self.bridges.items():
-                while bridge.serial.in_waiting:
-                    message = bridge.receive()
+                if bridge.serial.in_waiting:
+                    message = bridge.receive()  # ブロッキング処理
                     try:
                         data = json.loads(message)
                         logging.info(f"RECV {target} {data}")
                         self.callback(target, data)
                     except json.decoder.JSONDecodeError:
                         pass
-
-            # 送信
-            while not self.send_queue.empty():
-                target, data = self.send_queue.get()
-                logging.info(f"SEND {target} {data}")
-                bridge = self.bridges[target]
-                message = json.dumps(data)
-                bridge.send(message)
 
     def send(self, target: BridgeTarget, data: Any) -> None:
         """

--- a/ptcs/ptcs_server/button.py
+++ b/ptcs/ptcs_server/button.py
@@ -10,13 +10,13 @@ ButtonCallback = Callable[[Any], None]
 
 class Button:
     callback: ButtonCallback
-    thread: Optional[threading.Thread]
+    recv_thread: Optional[threading.Thread]
 
     def __init__(self, port: str, callback: ButtonCallback) -> None:
         baudrate = 115200
         self.serial = serial.Serial(port, baudrate, timeout=3.0)
         self.callback = callback
-        self.thread = None
+        self.recv_thread = None
 
     def print_ports(self) -> None:
         print("ports:")
@@ -26,33 +26,31 @@ class Button:
 
     def start(self) -> None:
         """
-        送受信スレッドを開始する。
+        受信スレッドを開始する。
         """
         thread = threading.Thread(target=self._run, daemon=True)
         thread.start()
-        self.thread = thread
+        self.recv_thread = thread
 
     def close(self) -> None:
         self.serial.close()
 
     def _run(self) -> None:
         """
-        スレッドの中身。
-        ブリッジから受信したデータがあれば、コールバックを呼び出す。
-        送信キューにデータがあれば、ブリッジに送信する。
+        受信スレッドの中身。
+        ボタンから受信したデータがあれば、コールバックを呼び出す。
         """
 
         while True:
-            # 受信
-            while self.serial.in_waiting:
-                message = self.receive()
+            if self.serial.in_waiting:
+                message = self.receive()  # ブロッキング処理
                 try:
                     data = json.loads(message)
                     logging.info(f"RECV {data}")
                     self.callback(data)
                 except json.decoder.JSONDecodeError:
                     pass
-    
+
     def receive(self) -> str:
         message = self.serial.readline()
         message_string = message.decode("utf-8")

--- a/ptcs/ptcs_server/points.py
+++ b/ptcs/ptcs_server/points.py
@@ -15,8 +15,9 @@ class PointSwitcher:
 
     def send(self, message: tuple[int, int]) -> None:
         servo_id, servo_state = message
-        self.serial.write(servo_id.to_bytes(1, 'little'))
-        self.serial.write(servo_state.to_bytes(1, 'little'))
+        self.serial.write(servo_id.to_bytes(1, "little"))
+        self.serial.write(servo_state.to_bytes(1, "little"))
+        self.serial.flush()
 
     def close(self) -> None:
         self.serial.close()
@@ -29,12 +30,12 @@ PointDict = dict[PointTarget, tuple[PointSwitcher, int]]
 class PointSwitcherManager:
     points: PointDict
     send_queue: queue.Queue[tuple[PointTarget, Any]]
-    thread: Optional[threading.Thread]
+    send_thread: Optional[threading.Thread]
 
     def __init__(self) -> None:
         self.points = {}
         self.send_queue = queue.Queue()
-        self.thread = None
+        self.send_thread = None
 
     def print_ports(self) -> None:
         print("ports:")
@@ -55,26 +56,24 @@ class PointSwitcherManager:
 
     def start(self) -> None:
         """
-        送受信スレッドを開始する。
+        送信スレッドを開始する。
         """
-        thread = threading.Thread(target=self._run, daemon=True)
-        thread.start()
-        self.thread = thread
+        send_thread = threading.Thread(target=self._run_send, daemon=True)
+        send_thread.start()
+        self.send_thread = send_thread
 
-    def _run(self) -> None:
+    def _run_send(self) -> None:
         """
-        スレッドの中身。
+        送信スレッドの中身。
         送信キューにデータがあれば、arduinoに送信する。
         """
 
         while True:
-            # 送信
-            while not self.send_queue.empty():
-                target, direction = self.send_queue.get()
-                logging.info(f"SEND {target} {direction}")
-                point_switcher, servo_no = self.points[target]
-                servo_state = 0 if direction == Direction.STRAIGHT else 1
-                point_switcher.send((servo_no, servo_state))
+            target, direction = self.send_queue.get()  # ブロッキング処理
+            logging.info(f"SEND {target} {direction}")
+            point_switcher, servo_no = self.points[target]
+            servo_state = 0 if direction == Direction.STRAIGHT else 1
+            point_switcher.send((servo_no, servo_state))
 
     def send(self, target: PointTarget, direction: Direction) -> None:
         """

--- a/ptcs/pyproject.toml
+++ b/ptcs/pyproject.toml
@@ -12,6 +12,7 @@ packages = [
 
 [tool.poetry.scripts]
 server = "ptcs_server.cli:main"
+scan = "serial.tools.list_ports:main"
 
 [tool.poetry.dependencies]
 python = "^3.10"

--- a/ptcs/usb_bt_bridge/bridge.py
+++ b/ptcs/usb_bt_bridge/bridge.py
@@ -8,7 +8,16 @@ class Bridge:
 
     def __init__(self, port: str) -> None:
         baudrate = 115200
-        self.serial = serial.Serial(port, baudrate, timeout=3.0, write_timeout=3.0)
+        self.serial = serial.Serial()
+        self.serial.port = port
+        self.serial.baudrate = baudrate
+        self.serial.timeout = 3.0
+        self.serial.write_timeout = 3.0
+        self.serial.rtscts = False  # 以下はポートopen時のESPリセット防止に必要
+        self.serial.dsrdtr = False
+        self.serial.dtr = 0
+        self.serial.rts = 0
+        self.serial.open()
 
     def send(self, message: str) -> None:
         self.serial.write(bytes(message, "ascii"))

--- a/ptcs/usb_bt_bridge/bridge.py
+++ b/ptcs/usb_bt_bridge/bridge.py
@@ -21,6 +21,7 @@ class Bridge:
 
     def send(self, message: str) -> None:
         self.serial.write(bytes(message, "ascii"))
+        self.serial.flush()
 
     def receive(self) -> str:
         message = self.serial.readline()


### PR DESCRIPTION
システムと基地局と車両の3社の問題により通信不安定が起きており、このうち「システム」と「基地局」に対する修正です。車両に対する修正は「fix/train-com-lost」ブランチで行っています。

## 原因
- pyserial がCOMポートを開くときに、COMポートにつながっている基地局ESP32がリセットされる。これにより、
  - bridge リセット → train.ino が SerialBT.flush() に失敗し数秒間通信処理が止まる → bridgeがtrainの発見に失敗するが、再接続を試みないコードになっていた

## 解決
- connected == false の間は基地局は再接続を試み続ける
- pyserial でESP32がリセットしないようにした https://github.com/pyserial/pyserial/issues/124

```python
        baudrate = 115200
        self.serial = serial.Serial()
        self.serial.port = port
        self.serial.baudrate = baudrate
        self.serial.timeout = 3.0
        self.serial.write_timeout = 3.0
        self.serial.rtscts = False  # ここ以下がポートopen時のESPリセット防止に必要
        self.serial.dsrdtr = False
        self.serial.dtr = 0
        self.serial.rts = 0
        self.serial.open()
```
