### PR TITLE
通信不安定現象の改善(列車側)

### DIFF
--- a/pc_changable/Usb_bt_bridge/Usb_bt_bridge.ino
+++ b/pc_changable/Usb_bt_bridge/Usb_bt_bridge.ino
@@ -3,26 +3,26 @@
 
 BluetoothSerial SerialBT;
 
-bool connected;
+bool connected = false;
 const int BUFFER_SIZE = 32;
 char buf[BUFFER_SIZE];
 char buf2[BUFFER_SIZE];
 
 void setup() {
+    Serial.begin(115200);
+    SerialBT.begin("ESP32_sender", true); 
+    //上のtrueはmasterであることを示す
 
-  pinMode( 5, OUTPUT);
-  Serial.begin(115200);
-  SerialBT.begin("ESP32_sender", true); 
-  //上のtrueはmasterであることを示す
-  connected = SerialBT.connect("ESP32-Dr");
-  //addressはname or Macaddressを引数にとる。前者はmax30ms後者はmax10ms程度の秒数で接続可能
-  
-    if(connected){
-        Serial.println("Connected Succesfully!");
-    }
-    else {
-        while(!SerialBT.connected(10000)) {
-        Serial.println("Failed to connect. Make sure remote device is available and in range, then restart app."); 
+    while (!connected) {
+        Serial.println("Connecting...");
+        connected = SerialBT.connect("ESP32-E5");
+        //addressはname or Macaddressを引数にとる。前者はmax30ms後者はmax10ms程度の秒数で接続可能
+
+        if(connected){
+            Serial.println("Connected Succesfully!");
+        }
+        else {
+            Serial.println("Failed to connect. Make sure remote device is available and in range, then restart app."); 
         }
     }
   

--- a/ptcs/usb_bt_bridge/bridge.py
+++ b/ptcs/usb_bt_bridge/bridge.py
@@ -4,11 +4,20 @@ import time
 
 
 class Bridge:
-    serial: serial.Serial
+    serial: "serial.Serial"
 
     def __init__(self, port: str) -> None:
         baudrate = 115200
-        self.serial = serial.Serial(port, baudrate, timeout=3.0, write_timeout=3.0)
+        self.serial = serial.Serial()
+        self.serial.port = port
+        self.serial.baudrate = baudrate
+        self.serial.timeout = 3.0
+        self.serial.write_timeout = 3.0
+        self.serial.rtscts = False  # 以下はポートopen時のESPリセット防止に必要
+        self.serial.dsrdtr = False
+        self.serial.dtr = 0
+        self.serial.rts = 0
+        self.serial.open()
 
     def send(self, message: str) -> None:
         self.serial.write(bytes(message, "ascii"))

--- a/train/Train.h
+++ b/train/Train.h
@@ -89,6 +89,12 @@ void Train::sendData(String key, int value) {
     doc_s[key]=value;
     serializeJson(doc_s,send_data);
     SerialBT.println(send_data);
+    unsigned int flush_start_time = millis();
     SerialBT.flush();  // SerialBTで正しく送信するために必要
+    // flushに500ms以上要した場合、基地局から切断されたと判断して止まる
+    if (millis() - flush_start_time > 500) {
+        motorInput = 0;
+        Serial.println("[sendData] too long times required for flush()!");
+    }
     Serial.println(send_data);
 }

--- a/train/train_controller.py
+++ b/train/train_controller.py
@@ -25,8 +25,16 @@ if __name__ == "__main__":
     try:
         port = '/dev/tty.usbserial-144130' # ポート名は環境に合わせて変更する
         baudrate = 115200
-        ser = serial.Serial(port, baudrate,timeout=3.0,write_timeout=3.0)
-        ser.read_until(b'}')
+        ser = serial.Serial()
+        ser.port = port
+        ser.baudrate = baudrate
+        ser.timeout = 3.0
+        ser.write_timeout = 3.0
+        ser.rtscts = False
+        ser.dsrdtr = False
+        ser.dtr = 0
+        ser.rts = 0
+        ser.open()
         time.sleep(3)
         while(True):
             new_time = time.time()


### PR DESCRIPTION
#38 とおなじモチベです。

列車側のバグの本質は、すでに train ブランチにマージした
- `sendData()` 内で `SerialBT.flush()` をしないとデータが送られないことがある 5f7ff8437b28a15cf74b923d647e8c06714cfb2c
- train_controller.py で ser のデコードを2回に1回しか行わない実装になっていた ` dea801c2be2dab826fb4310dc325ea7f6f44c206
```python
if (receive(ser)):   # ←ココで receive したデータは json.loads されず、
    recv_data = json.loads(receive(ser))  # ←次に来たデータが json.loads される
    print(recv_data)
    keys = recv_data.keys()
    if 'mR' in keys:
        motorRotation = recv_data['mR']
        mileage_cm_ += motorRotation * GEAR_RATIO * WHEEL_DIAMETER_cm_ * PI
    if 'pID' in keys:
        print(mileage_cm_)
        mileage_cm_ = 0
```

の2点です。

このブランチの変更として、基地局が落ちた時にinputを0にするようにしました。**通信が落ちたら、車両のリセットを押さず、基地局のリセットを押すことで、車両と基地局の両方を初期状態に戻すことができます**