### PR TITLE
列車との通信のキューイングを改善

### DIFF
--- a/ptcs/ptcs_control/railway_config.py
+++ b/ptcs/ptcs_control/railway_config.py
@@ -1,3 +1,4 @@
+import math
 from pydantic import BaseModel, Field
 from .components import Joint, Junction, Position, Section, Station, Stop, Train
 from .constants import (
@@ -110,7 +111,7 @@ class TrainConfig(BaseModel):
         elif speed <= 0:
             return 0
         else:
-            return (
+            return math.floor(
                 self.min_input
                 + (self.max_input - self.min_input) * speed / self.max_speed
             )

--- a/ptcs/ptcs_server/bridges.py
+++ b/ptcs/ptcs_server/bridges.py
@@ -75,13 +75,11 @@ class BridgeManager:
         """
 
         while True:
-            # 送信
-            while not self.send_queue.empty():
-                target, data = self.send_queue.get()
-                logging.info(f"SEND {target} {data}")
-                bridge = self.bridges[target]
-                message = json.dumps(data)
-                bridge.send(message)
+            target, data = self.send_queue.get()  # ブロッキング処理
+            logging.info(f"SEND {target} {data}")
+            bridge = self.bridges[target]
+            message = json.dumps(data)
+            bridge.send(message)
 
     def _run_recv(self) -> None:
         """
@@ -90,10 +88,9 @@ class BridgeManager:
         """
 
         while True:
-            # 受信
             for target, bridge in self.bridges.items():
                 if bridge.serial.in_waiting:
-                    message = bridge.receive()
+                    message = bridge.receive()  # ブロッキング処理
                     try:
                         data = json.loads(message)
                         logging.info(f"RECV {target} {data}")

--- a/ptcs/ptcs_server/bridges.py
+++ b/ptcs/ptcs_server/bridges.py
@@ -72,7 +72,7 @@ class BridgeManager:
         while True:
             # 受信
             for target, bridge in self.bridges.items():
-                while bridge.serial.in_waiting:
+                if bridge.serial.in_waiting:
                     message = bridge.receive()
                     try:
                         data = json.loads(message)

--- a/ptcs/ptcs_server/button.py
+++ b/ptcs/ptcs_server/button.py
@@ -44,7 +44,7 @@ class Button:
 
         while True:
             # 受信
-            while self.serial.in_waiting:
+            if self.serial.in_waiting:
                 message = self.receive()
                 try:
                     data = json.loads(message)

--- a/ptcs/ptcs_server/points.py
+++ b/ptcs/ptcs_server/points.py
@@ -17,6 +17,7 @@ class PointSwitcher:
         servo_id, servo_state = message
         self.serial.write(servo_id.to_bytes(1, 'little'))
         self.serial.write(servo_state.to_bytes(1, 'little'))
+        self.serial.flush()
 
     def close(self) -> None:
         self.serial.close()

--- a/ptcs/pyproject.toml
+++ b/ptcs/pyproject.toml
@@ -12,6 +12,7 @@ packages = [
 
 [tool.poetry.scripts]
 server = "ptcs_server.cli:main"
+scan = "serial.tools.list_ports:main"
 
 [tool.poetry.dependencies]
 python = "^3.10"

--- a/ptcs/usb_bt_bridge/bridge.py
+++ b/ptcs/usb_bt_bridge/bridge.py
@@ -21,6 +21,7 @@ class Bridge:
 
     def send(self, message: str) -> None:
         self.serial.write(bytes(message, "ascii"))
+        self.serial.flush()
 
     def receive(self) -> str:
         message = self.serial.readline()


### PR DESCRIPTION
このコミット https://github.com/plarailers/gogatsusai2023/pull/36/commits/8fd2208a3a1ff9fe2ebdff6878c580e2a1da7185 がまずくて、

`readline` で改行までバイトを受け取る間に、次のバイトも来ちゃって `in_waiting` になり続け、片方の列車からの受信しか行えていないのではという疑惑がある

各列車の送受信をちゃんとやるにはスレッドとキューをどう持つかちゃんと考える必要がたぶんあって、家で考えます……

ついでに、COM ポートスキャン用のコマンドを足しました

```bash
poetry run scan
```

マージ先は #38 になっていますが、main でもいいかも