### PR TITLE
stopに近づいていくときstop_distanceが変化しないのを修正

### DIFF
--- a/ptcs/ptcs_control/control.py
+++ b/ptcs/ptcs_control/control.py
@@ -659,6 +659,10 @@ class Control:
                     train_state.stop = forward_stop
                     train_state.stop_distance = forward_stop_distance
 
+            # 停止目標が変わらないとき
+            else:
+                train_state.stop_distance = forward_stop_distance
+
     def _get_forward_stop(self, train: Train) -> tuple[Stop, float] | None:
         """
         指定された列車が次にたどり着く停止位置とそこまでの距離を取得する。


### PR DESCRIPTION
駅に近づいていくとき、`stop_distance` が減っていかず、停止位置をすぎたときに突然 `stop_distance` がゼロになるバグがあったことに気付きました。とても小さい変更ですが一応。