### PR TITLE
RFIDからのAPS信号(pID)が到着しない

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.vscode
 *.vscode/*
 __pycache__/
+build

--- a/train/Train.h
+++ b/train/Train.h
@@ -89,12 +89,6 @@ void Train::sendData(String key, int value) {
     doc_s[key]=value;
     serializeJson(doc_s,send_data);
     SerialBT.println(send_data);
-    unsigned int flush_start_time = millis();
-    SerialBT.flush();  // SerialBTで正しく送信するために必要
-    // flushに500ms以上要した場合、基地局から切断されたと判断して止まる
-    if (millis() - flush_start_time > 500) {
-        motorInput = 0;
-        Serial.println("[sendData] too long times required for flush()!");
-    }
+    delay(1);
     Serial.println(send_data);
 }

--- a/train/train.ino
+++ b/train/train.ino
@@ -50,6 +50,10 @@ void loop(){
 
     /* モータ駆動 */
     int     motorInput      = train.getMotorInput();
+    // 基地局から切断された時はモータ停止
+    if (!train.SerialBT.connected()) {
+        motorInput = 0;
+    }
     train.moveMotor(motorInput);
 
     /* 100ms毎にモータ回転数を行う */


### PR DESCRIPTION
## 問題
RFID-APS からの `pID` 信号が ptcs に到達せず、運行に大きな支障が出ている。走行中に不具合が出ることが多く、また気まぐれ的に信号が来たり来なかったりする。

## 原因の推測
### 怪しい点：loop処理時間
`sendData` 関数の実行にやたら時間が掛かっているのではと推測したので、以下のtrain.inoを E6 に書き込み、「 loop が回るのに何秒かかっているか」を計測した。

```cpp
/* 車載統合ソフトウェア */
/* メインの処理を行う  */

#include "Train.h"
#include "adcRead.h"

Train train("ESP32-E6");

unsigned int old_time = 0;
unsigned int new_time = 0;

void setup() {
  // 略
}

int loop_count = 0;
unsigned long last_millis = 0;

void loop(){

    /* モータ駆動 */
    int     motorInput      = train.getMotorInput();
    train.moveMotor(motorInput);

    /* 100ms毎にモータ回転数を行う */
    new_time = millis();
    if (new_time - old_time > 100) {

        /* モータ回転数 */
        unsigned int   motorRotation   = motorRotationDetector.getRotation();
        // モータ回転しているときにmotorRotationを返す
        if (motorRotation > 0 && motorInput != 0) train.sendData("mR", motorRotation);

        old_time = new_time;
    }
    
    /* 停止検知(SS) */
    // bool    isStopping      = train.stopSensor.getStopping();
    // if (isStopping) train.sendData("iS", isStopping);

    /* 絶対位置検知(APS) */
    int     positionID      = train.positionID_Detector.getPositionID();
    if (positionID > 0) train.sendData("pID", positionID);

    /* フォトリフレクタAPS */
    // train.photoPositionID_Detector.setPhotoRefAnalogValue(getPhoto1(), getPhoto2());
    // int     photoPositionID = train.photoPositionID_Detector.getPhotoPositionID();
    // if (photoPositionID > 0) train.sendData("pID", photoPositionID);

    loop_count += 1;
    if (loop_count % 10 == 0) {
        unsigned long now = millis();
        Serial.print(loop_count);  // 何loop目か
        Serial.print(",");
        Serial.println(now - last_millis);  // 10loop回るのに何msかかったか
        last_millis = now;
    }
}
```

### やっぱり loop が遅い
* `{"mR":xx}` を Bluetooth 経由で送信しているとき、train.ino の loop が回るスピードが明らかに遅いことが判明した*

|条件|結果|
|---|---|
|有線シリアルを開いて{"mI":0}を送信| 25.6ms / loop |
|有線シリアルを開いて{"mI":100}を送信、モータが回転してmRが送られている| 25.6ms / loop|
|基地局経由でBT通信を開いて{"mI":0}を送信|25.6ms / loop|
|基地局経由でBT通信を開いて{"mI":50}を送信、モータが回転してmRが送られている|125.4ms / loop|
|基地局経由でBT通信を開いて{"mI":100}を送信、モータが回転してmRが送られている|125.4ms / loop|